### PR TITLE
fix: update README kvrocks installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ cd ..
 ```bash
 git clone https://github.com/KvrocksLabs/kvrocks.git
 cd kvrocks
-make -j4
+./x.py build
 cd ..
 ```
 


### PR DESCRIPTION
Hello, Thank you so much for developing a great tool :)　

`MakeFile` has been removed from `kvrocks` version `2.1.0` as follows.
- https://github.com/apache/kvrocks/releases/tag/v2.1.0
- https://github.com/apache/kvrocks/pull/576
- https://github.com/apache/kvrocks/pull/576/commits/5dd33a2920070273f441f90116c362f1d2de0a6e

Instead, it now uses `x.py` for building `kvrocks`
- https://github.com/apache/kvrocks/pull/729
- https://github.com/apache/kvrocks#build

So I changed the command in the README to `x.py`.

I would appreciate it if you could review.
Regards,