### PR TITLE
fix: Added exception handling when specify a key that does not exist in `SISMEMBER`

### DIFF
--- a/bin/caida_loader.py
+++ b/bin/caida_loader.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from ipaddress import ip_network
 from typing import Dict, Any
 
-from redis import Redis
+from redis import Redis, exceptions
 
 from ipasnhistory.default import get_socket_path, AbstractManager, get_config
 from ipasnhistory.helpers import get_data_dir
@@ -33,7 +33,10 @@ class CaidaLoader(AbstractManager):
         self.load_all()
 
     def already_loaded(self, address_family: str, date: str) -> bool:
-        return self.storagedb.sismember(f'{self.key_prefix}|{address_family}|dates', date)
+        try:
+            return self.storagedb.sismember(f'{self.key_prefix}|{address_family}|dates', date)
+        except exceptions.ResponseError:
+            return False
 
     def update_last(self, address_family: str, date: str) -> None:
         cur_last = self.storagedb.get(f'{self.key_prefix}|{address_family}|last')


### PR DESCRIPTION
I tried to fix #28 :)

## What Changed

- Fixed  #28
- Added exception handling when specify a key that does not exist in `SISMEMBER`

## Evidence
### Environment
Same as #28 reproduction environment

After this fix, I confirmed that ASN data can be added to `kvrocks` as follows.
```
2023-08-10 01:52:20,247 RipeDownloader INFO:Unreachable: http://data.ris.ripe.net/rrc00/2023.08/bview.20230810.0000.gz
2023-08-10 01:52:20,249 RipeDownloader INFO:Launching RipeDownloader
2023-08-10 01:52:20,250 RipeDownloader INFO:New file to download: rrc00/2023.08/bview.20230810.0000.gz
2023-08-10 01:52:21,102 CaidaDownloader INFO:Launching CaidaDownloader
2023-08-10 01:52:21,549 RipeDownloader INFO:Unreachable: http://data.ris.ripe.net/rrc00/2023.08/bview.20230810.0000.gz
2023-08-10 01:52:24,518 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v6/2023/08/routeviews-rv6-20230807-1000.pfx2as.gz
2023-08-10 01:52:30,057 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v6/2023/08/routeviews-rv6-20230806-1400.pfx2as.gz
2023-08-10 01:52:35,568 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v6/2023/08/routeviews-rv6-20230805-1200.pfx2as.gz
2023-08-10 01:52:41,109 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v6/2023/08/routeviews-rv6-20230804-1200.pfx2as.gz
2023-08-10 01:52:46,739 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v6/2023/08/routeviews-rv6-20230803-1200.pfx2as.gz
2023-08-10 01:52:52,608 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v6/2023/08/routeviews-rv6-20230802-1800.pfx2as.gz
2023-08-10 01:52:58,194 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v6/2023/08/routeviews-rv6-20230801-1400.pfx2as.gz
2023-08-10 01:53:03,891 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v6/2023/07/routeviews-rv6-20230731-1200.pfx2as.gz
2023-08-10 01:53:09,645 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v4/2023/08/routeviews-rv2-20230808-1200.pfx2as.gz
2023-08-10 01:53:25,972 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v4/2023/08/routeviews-rv2-20230807-1200.pfx2as.gz
2023-08-10 01:53:41,997 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v4/2023/08/routeviews-rv2-20230806-1200.pfx2as.gz
2023-08-10 01:53:58,768 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v4/2023/08/routeviews-rv2-20230805-2200.pfx2as.gz
2023-08-10 01:54:15,259 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v4/2023/08/routeviews-rv2-20230804-1400.pfx2as.gz
2023-08-10 01:54:32,416 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v4/2023/08/routeviews-rv2-20230803-1800.pfx2as.gz
2023-08-10 01:54:48,342 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v4/2023/08/routeviews-rv2-20230802-1200.pfx2as.gz
2023-08-10 01:55:05,402 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v4/2023/08/routeviews-rv2-20230801-1000.pfx2as.gz
2023-08-10 01:55:22,037 CaidaLoader INFO:Loading /home/fukusuke/IPASN-History/rawdata/caida/v4/2023/07/routeviews-rv2-20230731-1200.pfx2as.gz
```

I was able to run the API as follows.
```
$ curl http://127.0.0.1:5176/ip?ip=8.8.8.8
{"meta": {"ip": "8.8.8.8"}, "response": {"2023-08-08T12:00:00": {"asn": "15169", "prefix": "8.8.8.0/24", "source": "caida"}}}
```
I was able to run it from the GUI as follows.
<img width="897" alt="スクリーンショット 2023-08-10 2 07 33" src="https://github.com/D4-project/IPASN-History/assets/41001169/7a742f45-f116-4f0c-9200-1f713bc57be9">

I would appreciate it if you could review.
Regards,